### PR TITLE
Make Vocabulary robot-friendly by adding meta tags to the Styleguide

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -92,7 +92,18 @@ module.exports = {
   template: {
     head: {
       meta: [
-        { name: 'viewport', content: viewportMeta }
+        { name: 'viewport', content: viewportMeta },
+        //Open Graph
+        { property: 'og:title', content: 'vo·cab·u·lar·y' },
+        { property: 'og:type', content: 'website' },
+        { property: 'og:url', content: 'https://creativecommons.github.io/cc-vocabulary/' },
+        { property: 'og:description', content: 'A cohesive design system to unite the web-facing Creative Commons' },
+        { property: 'og:image', content: 'https://creativecommons.github.io/cc-vocabulary/titlecard.png' },
+        // Twitter
+        { name: 'twitter:title', content: 'vo·cab·u·lar·y' },
+        { name: 'twitter:card', content: 'summary_large_image' },
+        { name: 'twitter:description', content: 'A cohesive design system to unite the web-facing Creative Commons' },
+        { name: 'twitter:image', content: 'https://creativecommons.github.io/cc-vocabulary/titlecard.png' }
       ],
       links: [
         { rel: 'stylesheet', href: rootCss },


### PR DESCRIPTION
Fixes #26 

**Description**
Added Open Graph and Twitter meta tags to the Styleguide

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
